### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mpwg/Rebrickable-swift/security/code-scanning/1](https://github.com/mpwg/Rebrickable-swift/security/code-scanning/1)

To fix this problem, explicitly restrict the permissions the workflow uses with the `permissions` key. This can be done either at the workflow root level (applying to all jobs), or at the relevant job(s). Since the workflow only checks out code, caches dependencies, builds, and tests, it does not require any write access. Therefore, the minimal required permission is `contents: read`.  
The best way to fix this is to add a `permissions:` block to the root of `.github/workflows/ci.yml` (just after `name: CI` and before `on:`), setting `contents: read`. If in the future any step or action in this (or any job) requires additional permissions, they can be scoped specifically at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
